### PR TITLE
Add pagination, sorting and Swagger/OpenAPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,13 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- Swagger / OpenAPI -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+
         <!-- Liquibase -->
         <dependency>
             <groupId>org.liquibase</groupId>

--- a/src/main/java/com/book/store/app/controller/BookController.java
+++ b/src/main/java/com/book/store/app/controller/BookController.java
@@ -5,8 +5,10 @@ import com.book.store.app.dto.BookSearchParametersDto;
 import com.book.store.app.dto.CreateBookRequestDto;
 import com.book.store.app.service.BookService;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,8 +29,9 @@ public class BookController {
     private final BookService bookService;
 
     @GetMapping
-    public List<BookDto> getAll() {
-        return bookService.findAll();
+    public Page<BookDto> getAll(
+            @PageableDefault(size = 10, sort = "title") Pageable pageable) {
+        return bookService.findAll(pageable);
     }
 
     @GetMapping("/{id}")
@@ -55,7 +58,9 @@ public class BookController {
     }
 
     @GetMapping("/search")
-    public List<BookDto> searchBooks(@ModelAttribute BookSearchParametersDto params) {
-        return bookService.search(params);
+    public Page<BookDto> searchBooks(
+            @ModelAttribute BookSearchParametersDto params,
+            @PageableDefault(size = 10, sort = "title") Pageable pageable) {
+        return bookService.search(params, pageable);
     }
 }

--- a/src/main/java/com/book/store/app/service/BookService.java
+++ b/src/main/java/com/book/store/app/service/BookService.java
@@ -3,12 +3,13 @@ package com.book.store.app.service;
 import com.book.store.app.dto.BookDto;
 import com.book.store.app.dto.BookSearchParametersDto;
 import com.book.store.app.dto.CreateBookRequestDto;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface BookService {
     BookDto save(CreateBookRequestDto dto);
 
-    List<BookDto> findAll();
+    Page<BookDto> findAll(Pageable pageable);
 
     BookDto findById(Long id);
 
@@ -16,5 +17,5 @@ public interface BookService {
 
     void delete(Long id);
 
-    List<BookDto> search(BookSearchParametersDto params);
+    Page<BookDto> search(BookSearchParametersDto params, Pageable pageable);
 }

--- a/src/main/java/com/book/store/app/service/BookServiceImpl.java
+++ b/src/main/java/com/book/store/app/service/BookServiceImpl.java
@@ -9,8 +9,9 @@ import com.book.store.app.entity.Book;
 import com.book.store.app.exception.EntityNotFoundException;
 import com.book.store.app.mapper.BookMapper;
 import com.book.store.app.repository.BookRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,10 +32,9 @@ public class BookServiceImpl implements BookService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<BookDto> findAll() {
-        return bookRepository.findByDeletedFalse().stream()
-                .map(bookMapper::toDto)
-                .toList();
+    public Page<BookDto> findAll(Pageable pageable) {
+        return bookRepository.findAll(pageable)
+                .map(bookMapper::toDto);
     }
 
     @Override
@@ -65,9 +65,8 @@ public class BookServiceImpl implements BookService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<BookDto> search(BookSearchParametersDto params) {
-        return bookRepository.findAll(withSearchParams(params)).stream()
-                .map(bookMapper::toDto)
-                .toList();
+    public Page<BookDto> search(BookSearchParametersDto params, Pageable pageable) {
+        return bookRepository.findAll(withSearchParams(params), pageable)
+                .map(bookMapper::toDto);
     }
 }


### PR DESCRIPTION
- Implemented pagination and sorting support in controllers:
  • `BookController` now accepts Pageable with defaults (size=10, sort=title).
  • `BookService` and `BookServiceImpl` return Page<BookDto> and delegate to JPA repository.
- Fixed import ordering and style per Checkstyle rules:
  • Replaced wildcard imports with explicit imports.
  • Moved static import `withSearchParams` to the top of imports.
- Added `springdoc-openapi-starter-webmvc-ui` dependency in `pom.xml` for API documentation.