### PR TITLE
Add Docker support: Dockerfile, .env, docker-compose.yml with MySQL integration and environment variables for JWT

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+MYSQLDB_ROOT_PASSWORD=VeryStrongRootPass123!
+MYSQLDB_USER=bookstore_user
+MYSQLDB_PASSWORD=BookstorePass2025
+MYSQLDB_DATABASE=bookstore_db
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Maven & IDE
 HELP.md
 target/
 !.mvn/wrapper/maven-wrapper.jar
@@ -31,3 +32,7 @@ build/
 
 ### VS Code ###
 .vscode/
+
+.env
+
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM maven:3.9.2-eclipse-temurin-17 AS builder
+
+WORKDIR /app
+
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+COPY src ./src
+RUN mvn clean package -DskipTests -B
+
+FROM eclipse-temurin:17-jdk-jammy
+
+WORKDIR /app
+
+COPY --from=builder /app/target/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.8'
+
+services:
+  db:
+    image: mysql:8.0
+    container_name: bookstore-mysql
+    env_file:
+      - .env
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQLDB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQLDB_DATABASE}
+      MYSQL_USER: ${MYSQLDB_USER}
+      MYSQL_PASSWORD: ${MYSQLDB_PASSWORD}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: bookstore-app:latest
+    container_name: bookstore-app
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/${MYSQLDB_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+      SPRING_DATASOURCE_USERNAME: ${MYSQLDB_USER}
+      SPRING_DATASOURCE_PASSWORD: ${MYSQLDB_PASSWORD}
+
+volumes:
+  mysql_data:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/bookstore
-spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.url=${SPRING_DATASOURCE_URL\
+  :jdbc:mysql://localhost:3306/bookstore?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:root}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:root}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.open-in-view=false
@@ -17,6 +18,5 @@ springdoc.swagger-ui.operationsSorter=alpha
 springdoc.swagger-ui.tagsSorter=alpha
 springdoc.packagesToScan=com.book.store.app.controller
 
-jwt.secret=1wqZEzhGWkW1XEbrLLfjwplBlKkZRx2W17ZLgr2C05M=
-jwt.expiration=86400000
-
+jwt.secret=${JWT_SECRET:WmOhWQ/sJ+X9VUEnmU6L3c4rk3YI1xVfZHNp0Y3V6I=}  
+jwt.expiration=${JWT_EXPIRATION_MS:86400000}


### PR DESCRIPTION
- Dockerfile for building the Spring Boot application
- .env file containing environment variables:
  - MYSQLDB_DATABASE, MYSQLDB_USER, MYSQLDB_PASSWORD, etc.
  - JWT_SECRET and related configuration
- docker-compose.yml to run the application with a MySQL container
- Updated application.properties to read database and JWT values from environment variables
